### PR TITLE
feat: add HOCON configurator

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ simplecloud-metrics = { module = "app.simplecloud:internal-metrics-api", version
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 
 configurate-yaml = { module = "org.spongepowered:configurate-yaml", version.ref = "configurate" }
+configurate-hocon = { module = "org.spongepowered:configurate-hocon", version.ref = "configurate" }
 configurate-gson = { module = "org.spongepowered:configurate-gson", version.ref = "configurate" }
 configurate-extra-kotlin = { module = "org.spongepowered:configurate-extra-kotlin", version.ref = "configurate" }
 
@@ -65,6 +66,7 @@ log4j = [
 configurate = [
     "configurate-yaml",
     "configurate-gson",
+    "configurate-hocon",
     "configurate-extra-kotlin"
 ]
 night-config = [

--- a/serverhost-configurator/src/main/kotlin/app/simplecloud/serverhost/configurator/ConfiguratorType.kt
+++ b/serverhost-configurator/src/main/kotlin/app/simplecloud/serverhost/configurator/ConfiguratorType.kt
@@ -6,6 +6,7 @@ enum class ConfiguratorType(val configurator: Configurator<*>) {
     YML(YamlConfigurator),
     PROPERTIES(PropertiesConfigurator),
     TOML(TomlConfigurator),
+    HOCON(HoconConfigurator),
     JSON(JsonConfigurator),
     TXT(TextConfigurator);
 }

--- a/serverhost-configurator/src/main/kotlin/app/simplecloud/serverhost/configurator/impl/HoconConfigurator.kt
+++ b/serverhost-configurator/src/main/kotlin/app/simplecloud/serverhost/configurator/impl/HoconConfigurator.kt
@@ -1,0 +1,29 @@
+package app.simplecloud.serverhost.configurator.impl
+
+import app.simplecloud.serverhost.configurator.Configurator
+import org.spongepowered.configurate.ConfigurationNode
+import org.spongepowered.configurate.hocon.HoconConfigurationLoader
+import java.io.File
+
+object HoconConfigurator : Configurator<ConfigurationNode> {
+    override fun load(data: ConfigurationNode): ConfigurationNode {
+        return data
+    }
+
+    override fun load(file: File): ConfigurationNode? {
+        if (!file.exists()) return null
+        val loader = HoconConfigurationLoader.builder().file(file).build()
+        return loader.load()
+    }
+
+    override fun save(data: ConfigurationNode, file: File) {
+        val existing = load(file)
+        val saved: ConfigurationNode = if (existing == null) {
+            data
+        } else {
+            data.mergeFrom(existing.copy())
+        }
+        val loader = HoconConfigurationLoader.builder().file(file).build()
+        loader.save(saved)
+    }
+}


### PR DESCRIPTION
This adds the [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md) configuration format to the configurator. HOCON is used by [Arclight](https://wiki.izzel.io/s/arclight-docs/doc/configurations-LVLsOEMhu8) (a bukkit server implementation which includes different mod loaders) and is need to set the forwarding secret required for modern forwarding.

The format is already implemented in SpongePowered/configurate, so I only had to add the library, the type and the class. I made sure to make it identical to the JSON and YAML implementations!